### PR TITLE
Re-runner process for AQA tests

### DIFF
--- a/.github/workflows/paralleltest.yml
+++ b/.github/workflows/paralleltest.yml
@@ -33,6 +33,11 @@ on:
         description: Number of testLists to generate
         required: false
         default: '4'
+      storage_container:
+        description: Storage Container
+        required: true
+        type: string
+        default: ''
 
 # Dynamically set the name of the test-run
 run-name: Test JDK${{ inputs.version }}u on ${{ inputs.pool }}
@@ -81,7 +86,7 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
-          AZURE_STORAGE_CONTAINER: ${{ secrets.AZURE_STORAGE_CONTAINER }}
+          AZURE_STORAGE_CONTAINER: ${{ inputs.storage_container }}
 
       - name: Setup test environment
         run: |

--- a/.github/workflows/rerunner.yml
+++ b/.github/workflows/rerunner.yml
@@ -75,14 +75,11 @@ jobs:
           python ./scripts/vendors/microsoft/configure.py --pool ${{ inputs.pool }} --testLists 0
 
   run-aqa-parallel:
-    name: Execute ${{ matrix.suite }} ${{ inputs.aqa-targets }}
-    runs-on: ${{ fromJSON(needs.configuration.outputs.agent-config) }}
+    name: Execute ${{ inputs.suite }} ${{ inputs.aqa-targets }}
+#     runs-on: ${{ fromJSON(needs.configuration.outputs.agent-config) }}
+    runs-on: ubuntu-latest
     needs: [configuration]
     timeout-minutes: 1440
-    strategy:
-      fail-fast: false
-      matrix:
-        suite: ${{ inputs.suite }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -106,17 +103,17 @@ jobs:
         if: ${{ runner.os == 'linux' }}
         uses: ./.github/vendor-templates/microsoft/configure_linux
 
-      - name: Run ${{ matrix.suite }} ${{ inputs.aqa-targets }}
+      - name: Run ${{ inputs.suite }} ${{ inputs.aqa-targets }}
         uses: adoptium/run-aqa@v2.0.1
         with:
           jdksource: 'customized'
           aqa-testsRepo: ${{ inputs.aqatest-repo }}
-          build_list: ${{ matrix.suite }}
+          build_list: ${{ inputs.suite }}
           target : _testList TESTLIST=${{ inputs.aqa-targets }}
           version: ${{ inputs.version }}
 
       - uses: actions/upload-artifact@v2
         if: always() # Always run this step (even if the tests failed)
         with:
-          name: test_output_${{ matrix.suite }}
+          name: test_output_${{ inputs.suite }}
           path: ./**/output_*/*.tap

--- a/.github/workflows/rerunner.yml
+++ b/.github/workflows/rerunner.yml
@@ -68,7 +68,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-        # TODO: Setup will need to be optional on the number of test lists.
       - name: Setup
         id: setup
         run: |
@@ -76,8 +75,7 @@ jobs:
 
   run-aqa-parallel:
     name: Execute ${{ inputs.suite }} ${{ inputs.aqa-targets }}
-#     runs-on: ${{ fromJSON(needs.configuration.outputs.agent-config) }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(needs.configuration.outputs.agent-config) }}
     needs: [configuration]
     timeout-minutes: 1440
     steps:

--- a/.github/workflows/rerunner.yml
+++ b/.github/workflows/rerunner.yml
@@ -1,0 +1,117 @@
+name: Run AQAvit Paralleltest
+
+on:
+  workflow_dispatch: # Allows the job to be manually triggered
+    inputs:
+      customizedSdkUrl:
+        description: SDK URL
+        required: true
+        default: ''
+      aqatest-repo:
+        description: adoptium/aqa-tests repository
+        required: true
+        type: string
+        default: 'adoptium/aqa-tests:v1.0.0-release'
+      testImage:
+        description: Native Libs URL
+        required: true
+        default: ''
+      version:
+        description: JDK version
+        required: false
+        type: choice
+        options:
+          - '11'
+          - '17'
+          - '21'
+      suite:
+        description: AQAvit Test suite
+        required: true
+        type: choice
+        options:
+          - 'functional'
+          - 'openjdk'
+          - 'system'
+          - 'perf'
+      pool:
+        description: Agent Pool
+        required: true
+        type: string
+        default: None
+      aqa-targets:
+        description: OpenJDK test targets (comma separated)
+        required: true
+        default: ''
+
+# Dynamically set the name of the test-run
+run-name: Run JDK${{ inputs.version }}u ${{ inputs.pool }} ${{ inputs.aqa-targets }}
+
+env:  # Links to the JDK build under test and the native test libs
+  USE_TESTENV_PROPERTIES: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  configuration:
+    runs-on: ubuntu-latest
+    outputs:
+      agent-config: ${{ steps.setup.outputs.config }}
+      testLists: ${{ steps.setup.outputs.testConfig }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+        # TODO: Setup will need to be optional on the number of test lists.
+      - name: Setup
+        id: setup
+        run: |
+          python ./scripts/vendors/microsoft/configure.py --pool ${{ inputs.pool }} --testLists 0
+
+  run-aqa-parallel:
+    name: Execute ${{ matrix.suite }} ${{ inputs.aqa-targets }}
+    runs-on: ${{ fromJSON(needs.configuration.outputs.agent-config) }}
+    needs: [configuration]
+    timeout-minutes: 1440
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: ${{ inputs.suite }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Download artifacts
+        uses: ./.github/vendor-templates/microsoft/az_download_artifacts
+        with:
+          blobs: '${{ inputs.customizedSdkUrl }},${{ inputs.testImage }}'
+          destination_path: ${{ github.workspace }}/artifacts
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
+          AZURE_STORAGE_CONTAINER: ${{ secrets.AZURE_STORAGE_CONTAINER }}
+
+      - name: Setup test environment
+        run: |
+          python ./scripts/vendors/microsoft/setup_environment.py --source ${{ github.workspace }}/artifacts --destination ${{ github.workspace }}/jdk
+
+      - name: Configure linux
+        if: ${{ runner.os == 'linux' }}
+        uses: ./.github/vendor-templates/microsoft/configure_linux
+
+      - name: Run ${{ matrix.suite }} ${{ inputs.aqa-targets }}
+        uses: adoptium/run-aqa@v2.0.1
+        with:
+          jdksource: 'customized'
+          aqa-testsRepo: ${{ inputs.aqatest-repo }}
+          build_list: ${{ matrix.suite }}
+          target : _testList TESTLIST=${{ inputs.aqa-targets }}
+          version: ${{ inputs.version }}
+
+      - uses: actions/upload-artifact@v2
+        if: always() # Always run this step (even if the tests failed)
+        with:
+          name: test_output_${{ matrix.suite }}
+          path: ./**/output_*/*.tap

--- a/.github/workflows/rerunner.yml
+++ b/.github/workflows/rerunner.yml
@@ -42,6 +42,11 @@ on:
         description: OpenJDK test targets (comma separated)
         required: true
         default: ''
+      storage_container:
+        description: Storage Container
+        required: true
+        type: string
+        default: ''
 
 # Dynamically set the name of the test-run
 run-name: Run JDK${{ inputs.version }}u ${{ inputs.pool }} ${{ inputs.aqa-targets }}
@@ -91,7 +96,7 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
-          AZURE_STORAGE_CONTAINER: ${{ secrets.AZURE_STORAGE_CONTAINER }}
+          AZURE_STORAGE_CONTAINER: ${{ inputs.storage_container }}
 
       - name: Setup test environment
         run: |

--- a/scripts/vendors/microsoft/configure.py
+++ b/scripts/vendors/microsoft/configure.py
@@ -19,6 +19,10 @@ def get_runner_config(pool_name: str) -> str:
             else:
                 return f"config=['self-hosted', '1ES.Pool={ pool_name }']"
 
+def set_output_variables(output_variable: str) -> None:
+    with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+        print(output_variable, file=fh)
+
 def main(github_pool, num_lists):
   github_runner = None
   test_lists = []
@@ -26,9 +30,14 @@ def main(github_pool, num_lists):
   github_runner = get_runner_config(github_pool.lower())
   test_lists = set_number_of_test_lists(num_lists)
 
-  with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-    print(github_runner, file=fh)
-    print(f"testConfig={json.dumps(test_lists)}", file=fh)
+  if github_runner:
+    set_output_variables(github_runner)
+  else:
+    raise Exception(f"Runner configuration not found for pool: {github_pool}")
+
+  # Non-parallel runs will not leverage test lists
+  if test_lists > 0:
+    set_output_variables(f"testConfig={json.dumps(test_lists)}")
 
 if __name__ == "__main__":
 
@@ -39,4 +48,3 @@ if __name__ == "__main__":
 
   num_lists = args.testLists
   main(args.pool, num_lists)
-

--- a/scripts/vendors/microsoft/configure.py
+++ b/scripts/vendors/microsoft/configure.py
@@ -29,6 +29,7 @@ def main(github_pool, num_lists):
 
   github_runner = get_runner_config(github_pool.lower())
   test_lists = set_number_of_test_lists(num_lists)
+  print(test_lists)
 
   if github_runner:
     set_output_variables(github_runner)
@@ -36,7 +37,7 @@ def main(github_pool, num_lists):
     raise Exception(f"Runner configuration not found for pool: {github_pool}")
 
   # Non-parallel runs will not leverage test lists
-  if test_lists > 0:
+  if test_lists:
     set_output_variables(f"testConfig={json.dumps(test_lists)}")
 
 if __name__ == "__main__":
@@ -46,5 +47,6 @@ if __name__ == "__main__":
   parser.add_argument('--testLists', type=int, help='Number of test lists')
   args = parser.parse_args()
 
+  pool = args.pool
   num_lists = args.testLists
-  main(args.pool, num_lists)
+  main(pool, num_lists)


### PR DESCRIPTION
Adds a re-running process for AQA tests using the Github workflows available today.

This process should run test targets passed in as `aqa-targets` this should be a comma separated value. Which will be passed to the AQA framework to run the tests against.

This process should be able to run one to many aqa tests for a given aqa test suite.